### PR TITLE
Use the JSON handler in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ import (
 
 // Create a slog logger, which:
 //   - Logs to stdout.
-logger := slog.New(slog.NewTextHandler(os.Stdout, nil)),
+logger := slog.New(slog.NewJSONHandler(os.Stdout, nil)),
 
 app := fiber.New()
 


### PR DESCRIPTION
This PR adds the `NewJSONHandler` to the example in the README.md.