### PR TITLE
feat: add support for fiber.ErrorHandler logging

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,68 @@
+package slogfiber
+
+import (
+	"log/slog"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+const (
+	customAttributesCtxKey = "slog-fiber.custom-attributes"
+)
+
+var (
+	RequestBodyMaxSize  = 64 * 1024 // 64KB
+	ResponseBodyMaxSize = 64 * 1024 // 64KB
+
+	HiddenRequestHeaders = map[string]struct{}{
+		"authorization": {},
+		"cookie":        {},
+		"set-cookie":    {},
+		"x-auth-token":  {},
+		"x-csrf-token":  {},
+		"x-xsrf-token":  {},
+	}
+	HiddenResponseHeaders = map[string]struct{}{
+		"set-cookie": {},
+	}
+)
+
+type Config struct {
+	DefaultLevel     slog.Level
+	ClientErrorLevel slog.Level
+	ServerErrorLevel slog.Level
+
+	WithRequestID      bool
+	WithRequestBody    bool
+	WithRequestHeader  bool
+	WithResponseBody   bool
+	WithResponseHeader bool
+	WithSpanID         bool
+	WithTraceID        bool
+
+	Filters []Filter
+}
+
+// GetRequestID returns the request identifier
+func GetRequestID(c *fiber.Ctx) string {
+	requestID, ok := c.Context().UserValue("request-id").(string)
+	if !ok {
+		return ""
+	}
+
+	return requestID
+}
+
+// AddCustomAttributes adds custom attributes to the *fiber.Ctx.
+func AddCustomAttributes(c *fiber.Ctx, attr slog.Attr) {
+	v := c.Context().UserValue(customAttributesCtxKey)
+	if v == nil {
+		c.Context().SetUserValue(customAttributesCtxKey, []slog.Attr{attr})
+		return
+	}
+
+	switch attrs := v.(type) {
+	case []slog.Attr:
+		c.Context().SetUserValue(customAttributesCtxKey, append(attrs, attr))
+	}
+}

--- a/deprecated.go
+++ b/deprecated.go
@@ -1,0 +1,34 @@
+package slogfiber
+
+import (
+	"log/slog"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// New returns a fiber.Handler (middleware) that logs requests using slog.
+//
+// Requests with errors are logged using slog.Error().
+// Requests without errors are logged using slog.Info().
+//
+// Deprecated: Use NewMiddleware(...) instead.
+func New(logger *slog.Logger) fiber.Handler {
+	return NewMiddleware(logger)
+}
+
+// NewWithFilters returns a fiber.Handler (middleware) that logs requests using slog.
+//
+// Requests with errors are logged using slog.Error().
+// Requests without errors are logged using slog.Info().
+//
+// Deprecated: Use NewMiddlewareWithFilters(...) instead.
+func NewWithFilters(logger *slog.Logger, filters ...Filter) fiber.Handler {
+	return NewMiddlewareWithFilters(logger, filters...)
+}
+
+// NewWithConfig returns a fiber.Handler (middleware) that logs requests using slog.
+//
+// Deprecated: Use NewMiddlewareWithConfig(...) instead.
+func NewWithConfig(logger *slog.Logger, config Config) fiber.Handler {
+	return NewMiddlewareWithConfig(logger, config)
+}

--- a/error-handler.go
+++ b/error-handler.go
@@ -1,0 +1,62 @@
+package slogfiber
+
+import (
+	"log/slog"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+// NewErrorHandler returns a fiber.ErrorHandler that logs requests using slog.
+//
+// Requests with errors are logged using slog.Error().
+// Requests without errors are logged using slog.Info().
+func NewErrorHandler(logger *slog.Logger) fiber.ErrorHandler {
+	return NewErrorHandlerWithConfig(logger, Config{
+		DefaultLevel:     slog.LevelInfo,
+		ClientErrorLevel: slog.LevelWarn,
+		ServerErrorLevel: slog.LevelError,
+
+		WithRequestID:      true,
+		WithRequestBody:    false,
+		WithRequestHeader:  false,
+		WithResponseBody:   false,
+		WithResponseHeader: false,
+		WithSpanID:         false,
+		WithTraceID:        false,
+
+		Filters: []Filter{},
+	})
+}
+
+// NewErrorHandlerWithFilters returns a fiber.ErrorHandler that logs requests using slog.
+//
+// Requests with errors are logged using slog.Error().
+// Requests without errors are logged using slog.Info().
+func NewErrorHandlerWithFilters(logger *slog.Logger, filters ...Filter) fiber.ErrorHandler {
+	return NewErrorHandlerWithConfig(logger, Config{
+		DefaultLevel:     slog.LevelInfo,
+		ClientErrorLevel: slog.LevelWarn,
+		ServerErrorLevel: slog.LevelError,
+
+		WithRequestID:      true,
+		WithRequestBody:    false,
+		WithRequestHeader:  false,
+		WithResponseBody:   false,
+		WithResponseHeader: false,
+		WithSpanID:         false,
+		WithTraceID:        false,
+
+		Filters: filters,
+	})
+}
+
+// NewErrorHandlerWithConfig returns a fiber.ErrorHandler that logs requests using slog.
+func NewErrorHandlerWithConfig(logger *slog.Logger, config Config) fiber.ErrorHandler {
+	return func(c *fiber.Ctx, err error) error {
+		requestID := uuid.New().String()
+		// start := ??
+
+		return handle(config, logger, c, err, requestID, nil)
+	}
+}

--- a/examples/error-handler/example.go
+++ b/examples/error-handler/example.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"log/slog"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/recover"
+	slogfiber "github.com/samber/slog-fiber"
+	slogformatter "github.com/samber/slog-formatter"
+)
+
+func main() {
+	// Create a slog logger, which:
+	//   - Logs to stdout.
+	//   - RFC3339 with UTC time format.
+	logger := slog.New(
+		slogformatter.NewFormatterHandler(
+			slogformatter.TimezoneConverter(time.UTC),
+			slogformatter.TimeFormatter(time.RFC3339, nil),
+		)(
+			slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{}),
+		),
+	)
+
+	// Add an attribute to all log entries made through this logger.
+	logger = logger.With("env", "production")
+	errorHandlerLogger := slogfiber.NewErrorHandler(logger.WithGroup("http"))
+
+	app := fiber.New(fiber.Config{
+		AppName:      "hello world",
+		IdleTimeout:  0,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		ErrorHandler: func(ctx *fiber.Ctx, err error) error {
+			// ...
+			return errorHandlerLogger(ctx, err)
+		},
+	})
+
+	// config := slogfiber.Config{WithRequestBody: true, WithResponseBody: true, WithRequestHeader: true, WithResponseHeader: true}
+	// app.Use(slogfiber.NewWithConfig(logger, config))
+	app.Use(recover.New())
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		slogfiber.AddCustomAttributes(c, slog.String("foo", "bar"))
+		return c.SendString("Hello, World 👋!")
+	})
+
+	app.Get("/crashme", func(c *fiber.Ctx) error {
+		return c.Status(400).SendString("Oops i crashed :(")
+	})
+
+	app.Get("/foobar/:id", func(c *fiber.Ctx) error {
+		return c.SendString("Hello, World 👋!")
+	})
+
+	// 404 Handler
+	app.Use(func(c *fiber.Ctx) error {
+		return fiber.NewError(fiber.StatusNotFound)
+	})
+
+	err := app.Listen(":4242")
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+
+	// output:
+	// time=2023-04-10T14:00:00.000+00:00 level=INFO msg="Incoming request" env=production http.status=200 http.method=GET http.path=/ http.route=/ http.ip=::1 http.latency=25.958µs http.user-agent=curl/7.77.0 http.time=2023-04-10T14:00:00Z http.request-id=229c7fc8-64f5-4467-bc4a-940700503b0d
+}

--- a/examples/middleware/example.go
+++ b/examples/middleware/example.go
@@ -31,7 +31,7 @@ func main() {
 
 	app := fiber.New()
 
-	app.Use(slogfiber.New(logger.WithGroup("http")))
+	app.Use(slogfiber.NewMiddleware(logger.WithGroup("http")))
 	// config := slogfiber.Config{WithRequestBody: true, WithResponseBody: true, WithRequestHeader: true, WithResponseHeader: true}
 	// app.Use(slogfiber.NewWithConfig(logger, config))
 	app.Use(recover.New())
@@ -51,7 +51,7 @@ func main() {
 
 	// 404 Handler
 	app.Use(func(c *fiber.Ctx) error {
-		return c.SendStatus(fiber.StatusNotFound)
+		return fiber.NewError(fiber.StatusNotFound)
 	})
 
 	err := app.Listen(":4242")

--- a/middleware.go
+++ b/middleware.go
@@ -12,49 +12,12 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-const (
-	customAttributesCtxKey = "slog-fiber.custom-attributes"
-)
-
-var (
-	RequestBodyMaxSize  = 64 * 1024 // 64KB
-	ResponseBodyMaxSize = 64 * 1024 // 64KB
-
-	HiddenRequestHeaders = map[string]struct{}{
-		"authorization": {},
-		"cookie":        {},
-		"set-cookie":    {},
-		"x-auth-token":  {},
-		"x-csrf-token":  {},
-		"x-xsrf-token":  {},
-	}
-	HiddenResponseHeaders = map[string]struct{}{
-		"set-cookie": {},
-	}
-)
-
-type Config struct {
-	DefaultLevel     slog.Level
-	ClientErrorLevel slog.Level
-	ServerErrorLevel slog.Level
-
-	WithRequestID      bool
-	WithRequestBody    bool
-	WithRequestHeader  bool
-	WithResponseBody   bool
-	WithResponseHeader bool
-	WithSpanID         bool
-	WithTraceID        bool
-
-	Filters []Filter
-}
-
-// New returns a fiber.Handler (middleware) that logs requests using slog.
+// NewMiddleware returns a fiber.Handler (middleware) that logs requests using slog.
 //
 // Requests with errors are logged using slog.Error().
 // Requests without errors are logged using slog.Info().
-func New(logger *slog.Logger) fiber.Handler {
-	return NewWithConfig(logger, Config{
+func NewMiddleware(logger *slog.Logger) fiber.Handler {
+	return NewMiddlewareWithConfig(logger, Config{
 		DefaultLevel:     slog.LevelInfo,
 		ClientErrorLevel: slog.LevelWarn,
 		ServerErrorLevel: slog.LevelError,
@@ -71,12 +34,12 @@ func New(logger *slog.Logger) fiber.Handler {
 	})
 }
 
-// NewWithFilters returns a fiber.Handler (middleware) that logs requests using slog.
+// NewMiddlewareWithFilters returns a fiber.Handler (middleware) that logs requests using slog.
 //
 // Requests with errors are logged using slog.Error().
 // Requests without errors are logged using slog.Info().
-func NewWithFilters(logger *slog.Logger, filters ...Filter) fiber.Handler {
-	return NewWithConfig(logger, Config{
+func NewMiddlewareWithFilters(logger *slog.Logger, filters ...Filter) fiber.Handler {
+	return NewMiddlewareWithConfig(logger, Config{
 		DefaultLevel:     slog.LevelInfo,
 		ClientErrorLevel: slog.LevelWarn,
 		ServerErrorLevel: slog.LevelError,
@@ -93,12 +56,10 @@ func NewWithFilters(logger *slog.Logger, filters ...Filter) fiber.Handler {
 	})
 }
 
-// NewWithConfig returns a fiber.Handler (middleware) that logs requests using slog.
-func NewWithConfig(logger *slog.Logger, config Config) fiber.Handler {
+// NewMiddlewareWithConfig returns a fiber.Handler (middleware) that logs requests using slog.
+func NewMiddlewareWithConfig(logger *slog.Logger, config Config) fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		c.Path()
 		start := time.Now()
-		path := c.Path()
 
 		requestID := uuid.New().String()
 		if config.WithRequestID {
@@ -108,134 +69,120 @@ func NewWithConfig(logger *slog.Logger, config Config) fiber.Handler {
 
 		err := c.Next()
 
-		end := time.Now()
-		latency := end.Sub(start)
-		status := c.Response().StatusCode()
-
-		ip := c.Context().RemoteIP().String()
-		if len(c.IPs()) > 0 {
-			ip = c.IPs()[0]
-		}
-
-		attributes := []slog.Attr{
-			slog.Time("time", end),
-			slog.Duration("latency", latency),
-			slog.String("method", string(c.Context().Method())),
-			slog.String("host", c.Hostname()),
-			slog.String("path", path),
-			slog.String("route", c.Route().Path),
-			slog.Int("status", status),
-			slog.String("ip", ip),
-			slog.String("user-agent", string(c.Context().UserAgent())),
-			slog.String("referer", c.Get(fiber.HeaderReferer)),
-		}
-
-		if len(c.IPs()) > 0 {
-			attributes = append(attributes, slog.Any("x-forwarded-for", c.IPs()))
-		}
-
-		if config.WithRequestID {
-			attributes = append(attributes, slog.String("request-id", requestID))
-		}
-
-		// otel
-		if config.WithTraceID {
-			traceID := trace.SpanFromContext(c.Context()).SpanContext().TraceID().String()
-			attributes = append(attributes, slog.String("trace-id", traceID))
-		}
-		if config.WithSpanID {
-			spanID := trace.SpanFromContext(c.Context()).SpanContext().SpanID().String()
-			attributes = append(attributes, slog.String("span-id", spanID))
-		}
-
-		// request
-		if config.WithRequestBody {
-			body := c.Body()
-			if len(body) > RequestBodyMaxSize {
-				body = body[:RequestBodyMaxSize]
-			}
-			attributes = append(attributes, slog.Group("request", slog.String("body", string(body))))
-		}
-		if config.WithRequestHeader {
-			for k, v := range c.GetReqHeaders() {
-				if _, found := HiddenRequestHeaders[strings.ToLower(k)]; found {
-					continue
-				}
-				attributes = append(attributes, slog.Group("request", slog.Group("header", slog.Any(k, v))))
-			}
-		}
-
-		// response
-		if config.WithResponseBody {
-			body := c.Response().Body()
-			if len(body) > ResponseBodyMaxSize {
-				body = body[:ResponseBodyMaxSize]
-			}
-			attributes = append(attributes, slog.Group("response", slog.String("body", string(body))))
-		}
-		if config.WithResponseHeader {
-			for k, v := range c.GetRespHeaders() {
-				if _, found := HiddenResponseHeaders[strings.ToLower(k)]; found {
-					continue
-				}
-				attributes = append(attributes, slog.Group("response", slog.Group("header", slog.Any(k, v))))
-			}
-		}
-
-		// custom context values
-		if v := c.Context().UserValue(customAttributesCtxKey); v != nil {
-			switch attrs := v.(type) {
-			case []slog.Attr:
-				attributes = append(attributes, attrs...)
-			}
-		}
-
-		logErr := err
-		if logErr == nil {
-			logErr = fiber.NewError(status)
-		}
-
-		for _, filter := range config.Filters {
-			if !filter(c) {
-				return logErr
-			}
-		}
-
-		level := config.DefaultLevel
-		msg := "Incoming request"
-		if status >= http.StatusInternalServerError {
-			level = config.ServerErrorLevel
-			msg = logErr.Error()
-		} else if status >= http.StatusBadRequest && status < http.StatusInternalServerError {
-			level = config.ClientErrorLevel
-			msg = logErr.Error()
-		}
-
-		logger.LogAttrs(c.UserContext(), level, msg, attributes...)
-
-		return err
+		return handle(config, logger, c, err, requestID, &start)
 	}
 }
 
-// GetRequestID returns the request identifier
-func GetRequestID(c *fiber.Ctx) string {
-	requestID, ok := c.Context().UserValue("request-id").(string)
-	if !ok {
-		return ""
+func handle(config Config, logger *slog.Logger, c *fiber.Ctx, err error, requestID string, start *time.Time) error {
+	status := c.Response().StatusCode()
+	path := string(c.Context().URI().PathOriginal())
+	end := time.Now()
+
+	ip := c.Context().RemoteIP().String()
+	if len(c.IPs()) > 0 {
+		ip = c.IPs()[0]
 	}
 
-	return requestID
-}
-
-func AddCustomAttributes(c *fiber.Ctx, attr slog.Attr) {
-	v := c.Context().UserValue(customAttributesCtxKey)
-	if v == nil {
-		c.Context().SetUserValue(customAttributesCtxKey, []slog.Attr{attr})
-		return
+	attributes := []slog.Attr{
+		slog.Time("time", end),
+		// slog.Duration("latency", latency),
+		slog.String("method", string(c.Context().Method())),
+		slog.String("host", c.Hostname()),
+		slog.String("path", path),
+		slog.String("route", c.Route().Path),
+		slog.Int("status", status),
+		slog.String("ip", ip),
+		slog.String("user-agent", string(c.Context().UserAgent())),
+		slog.String("referer", c.Get(fiber.HeaderReferer)),
 	}
 
-	switch attrs := v.(type) {
-	case []slog.Attr:
-		c.Context().SetUserValue(customAttributesCtxKey, append(attrs, attr))
+	if start != nil {
+		latency := end.Sub(*start)
+		attributes = append(attributes, slog.Duration("latency", latency))
 	}
+
+	if len(c.IPs()) > 0 {
+		attributes = append(attributes, slog.Any("x-forwarded-for", c.IPs()))
+	}
+
+	if config.WithRequestID {
+		attributes = append(attributes, slog.String("request-id", requestID))
+	}
+
+	// otel
+	if config.WithTraceID {
+		traceID := trace.SpanFromContext(c.Context()).SpanContext().TraceID().String()
+		attributes = append(attributes, slog.String("trace-id", traceID))
+	}
+	if config.WithSpanID {
+		spanID := trace.SpanFromContext(c.Context()).SpanContext().SpanID().String()
+		attributes = append(attributes, slog.String("span-id", spanID))
+	}
+
+	// request
+	if config.WithRequestBody {
+		body := c.Body()
+		if len(body) > RequestBodyMaxSize {
+			body = body[:RequestBodyMaxSize]
+		}
+		attributes = append(attributes, slog.Group("request", slog.String("body", string(body))))
+	}
+	if config.WithRequestHeader {
+		for k, v := range c.GetReqHeaders() {
+			if _, found := HiddenRequestHeaders[strings.ToLower(k)]; found {
+				continue
+			}
+			attributes = append(attributes, slog.Group("request", slog.Group("header", slog.Any(k, v))))
+		}
+	}
+
+	// response
+	if config.WithResponseBody {
+		body := c.Response().Body()
+		if len(body) > ResponseBodyMaxSize {
+			body = body[:ResponseBodyMaxSize]
+		}
+		attributes = append(attributes, slog.Group("response", slog.String("body", string(body))))
+	}
+	if config.WithResponseHeader {
+		for k, v := range c.GetRespHeaders() {
+			if _, found := HiddenResponseHeaders[strings.ToLower(k)]; found {
+				continue
+			}
+			attributes = append(attributes, slog.Group("response", slog.Group("header", slog.Any(k, v))))
+		}
+	}
+
+	// custom context values
+	if v := c.Context().UserValue(customAttributesCtxKey); v != nil {
+		switch attrs := v.(type) {
+		case []slog.Attr:
+			attributes = append(attributes, attrs...)
+		}
+	}
+
+	logErr := err
+	if logErr == nil {
+		logErr = fiber.NewError(status)
+	}
+
+	for _, filter := range config.Filters {
+		if !filter(c) {
+			return logErr
+		}
+	}
+
+	level := config.DefaultLevel
+	msg := "Incoming request"
+	if status >= http.StatusInternalServerError {
+		level = config.ServerErrorLevel
+		msg = logErr.Error()
+	} else if status >= http.StatusBadRequest && status < http.StatusInternalServerError {
+		level = config.ClientErrorLevel
+		msg = logErr.Error()
+	}
+
+	logger.LogAttrs(c.UserContext(), level, msg, attributes...)
+
+	return err
 }


### PR DESCRIPTION
This PR allows to move the logger into *fiber.ErrorHandler:

Use either:
- the middleware
- the error handler (prefered)


`NewXXX` constructors have been renamed to `NewMiddlewareXXX`. Previous functions are marked as deprecated.

## Via error handler

```go
app := fiber.NewMiddleware(fiber.Config{
        // ...
	ErrorHandler: slogfiber.NewErrorHandler(logger.WithGroup("http")),
})
```

## Via middleware

```go
app.Use(slogfiber.NewMiddleware(logger))
```
