### PR TITLE
Prevent middleware for replace response when applying filters

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -235,15 +235,15 @@ func NewWithConfig(logger *slog.Logger, config Config) fiber.Handler {
 			}
 		}
 
+		for _, filter := range config.Filters {
+			if !filter(c) {
+				return err
+			}
+		}
+
 		logErr := err
 		if logErr == nil {
 			logErr = fiber.NewError(status)
-		}
-
-		for _, filter := range config.Filters {
-			if !filter(c) {
-				return logErr
-			}
 		}
 
 		level := config.DefaultLevel


### PR DESCRIPTION
If a `Filter` applies, the response is replaced with a `200 OK` instead of the _actual_ response.

This change ensures the original `err` is returned when logging is being filtered, which will *not* affect the response body or response code.

Observed with

```
github.com/gofiber/fiber/v2 v2.50.0
```