### PR TITLE
fix: should use fiber.HeaderXRequestID

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 go get github.com/samber/slog-fiber
 
 # Fiber v3 (beta)
-go get github.com/samber/slog-echo@fiber-v3
+go get github.com/samber/slog-fiber@fiber-v3
 ```
 
 **Compatibility**: go >= 1.21

--- a/middleware.go
+++ b/middleware.go
@@ -2,12 +2,11 @@ package slogfiber
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
-
-	"log/slog"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/google/uuid"
@@ -38,7 +37,7 @@ var (
 	}
 
 	// Formatted with http.CanonicalHeaderKey
-	RequestIDHeaderKey = "X-Request-Id"
+	RequestIDHeaderKey = fiber.HeaderXRequestID
 )
 
 type Config struct {
@@ -126,7 +125,7 @@ func NewWithConfig(logger *slog.Logger, config Config) fiber.Handler {
 				requestID = uuid.New().String()
 			}
 			c.Context().SetUserValue("request-id", requestID)
-			c.Set("X-Request-ID", requestID)
+			c.Set(RequestIDHeaderKey, requestID)
 		}
 
 		err := c.Next()
@@ -309,7 +308,7 @@ func AddCustomAttributes(c fiber.Ctx, attr slog.Attr) {
 }
 
 func extractTraceSpanID(ctx context.Context, withTraceID bool, withSpanID bool) []slog.Attr {
-	if !(withTraceID || withSpanID) {
+	if !withTraceID && !withSpanID {
 		return []slog.Attr{}
 	}
 


### PR DESCRIPTION
fiber/v3 provided a const variable called `HeaderXRequestID`,

and the [`requestid`](https://docs.gofiber.io/next/middleware/requestid) middleware use it too.