### PR TITLE
feat(otel): propagate traceid as response header

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ type Config struct {
 
 Attributes will be injected in log payload.
 
+When `WithRequestID` is enabled, the request ID is also set as the `X-Request-Id` response header (customizable via `slogfiber.RequestIDHeaderKey`).
+
+When `WithTraceID` is enabled and an active OpenTelemetry span exists, the trace ID is also set as a response header. The header key defaults to `"X-Trace-Id"` and is customizable via `slogfiber.TraceIDHeaderKey`.
+
 Other global parameters:
 
 ```go
@@ -131,6 +135,7 @@ slogfiber.HiddenRequestHeaders = map[string]struct{}{ ... }
 slogfiber.HiddenResponseHeaders = map[string]struct{}{ ... }
 slogfiber.RequestIDContextKey = "request-id"
 slogfiber.RequestIDHeaderKey = "X-Request-Id"
+slogfiber.TraceIDHeaderKey = "X-Trace-Id"
 ```
 
 ### Minimal

--- a/middleware.go
+++ b/middleware.go
@@ -42,6 +42,7 @@ var (
 	RequestIDContextKey = "request-id"
 	// Formatted with http.CanonicalHeaderKey
 	RequestIDHeaderKey = "X-Request-Id"
+	TraceIDHeaderKey = "X-Trace-Id"
 )
 
 type Config struct {
@@ -126,6 +127,15 @@ func NewWithConfig(logger *slog.Logger, config Config) fiber.Handler {
 			}
 			c.Locals(RequestIDContextKey, requestID)
 			c.Set(RequestIDHeaderKey, requestID)
+		}
+
+		if config.WithTraceID {
+			span := trace.SpanFromContext(c)
+			if span.IsRecording() {
+				if spanCtx := span.SpanContext(); spanCtx.HasTraceID() {
+					c.Set(TraceIDHeaderKey, spanCtx.TraceID().String())
+				}
+			}
 		}
 
 		err := c.Next()


### PR DESCRIPTION
### Context

`WithRequestID` already propagates the request ID in response headers (`X-Request-Id` by default, configurable via `slogfiber.RequestIDHeaderKey`), which helps with debugging and log correlation.

This PR adds similar support for the OpenTelemetry Trace ID `WithTraceId`, exposed in response headers (`X-Trace-Id` by default, configurable via `slogfiber.TraceIDHeaderKey`).

Close #86 

### 🧠 Why this matters

Including the Trace ID in responses makes it easier to correlate:
- API requests ↔ logs  
- API requests ↔ distributed traces  

### 📖 Documentation

- Documents behavior of `WithRequestID` and `WithTraceID`
- Adds configuration details for:
  - `slogfiber.RequestIDHeaderKey`
  - `slogfiber.TraceIDHeaderKey`

**Note** : this PR has been generated with the help of Claude Sonnet 4.6 🤖.